### PR TITLE
Bump cmake min required version to 3.5 for metadata-parser

### DIFF
--- a/metadata-parser/CMakeLists.txt
+++ b/metadata-parser/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(metadata-parser)
 
 if (WIN32)


### PR DESCRIPTION
Fixes `Compatibility with CMake < 3.5 has been removed from CMake.` error for included `metadata-parser` directory.